### PR TITLE
add name attribute to hidden pi_select

### DIFF
--- a/app/helpers/pieces/rails/pi_helper.rb
+++ b/app/helpers/pieces/rails/pi_helper.rb
@@ -15,7 +15,7 @@ module Pieces
         merge_class! list_options, 'pi is-hidden list-container pi-select-list'
         options.delete :dropdown
         content_tag(:div, nil, options) do
-          concat hidden_field_tag(nil,val)
+          concat hidden_field_tag(options[:hidden_name], val)
           concat content_tag(:div, placeholder, class: 'pi placeholder', pid: "placeholder", data:{placeholder: placeholder})
           concat(
             content_tag(:div, nil, list_options) do


### PR DESCRIPTION
Сейчас если использовать pi_select_field без JS, используя Rails form helpers, то при генерации hidden input он не проставляет имя инпуту, из-за чего нельзя нормально послать на сервер данные.

Добавил возможность указать через хеш опций имя для инпута.
